### PR TITLE
修复 `parseUrlParams` Uncaught URIError: URI malformed

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -126,9 +126,12 @@ export function parseServerInfo(serverInfo) {
 	const [paramsOnly, ...fragmentParts] = paramsPart.split('#');
 	const searchParams = new URLSearchParams(paramsOnly);
 	const params = Object.fromEntries(searchParams.entries());
-  
-	const name = fragmentParts.length > 0 ? decodeURIComponent(fragmentParts.join('#')) : '';
-  
+
+	let name = fragmentParts.length > 0 ? fragmentParts.join('#') : '';
+	try {
+	    name = decodeURIComponent(name);
+	} catch (error) { };
+	
 	return { addressPart, params, name };
   }
   


### PR DESCRIPTION
某些订阅中会出现`邀请好友获得60%`这样的代理名称, 此处的%并非Url编码，从而使得`decodeURIComponent`出错